### PR TITLE
Update noPrefix

### DIFF
--- a/skpy/util.py
+++ b/skpy/util.py
@@ -15,7 +15,9 @@ def noPrefix(s):
     Returns:
         str: unprefixed string
     """
-    return s if s is None else s.split(":", 1)[1]
+    if s is None:
+        return ""
+    return ":".join(s.split(":", 1)[1:])
 
 
 def userToId(url):


### PR DESCRIPTION
Should handle usernames that look like `live:thing`.

I had a bug when trying to speak to someone who's name is `live:xxx`, and I think this patch fixed it.